### PR TITLE
Set workflow reference to `RELEASE`

### DIFF
--- a/.github/workflows/list-Github-models.yml
+++ b/.github/workflows/list-Github-models.yml
@@ -19,6 +19,6 @@ jobs:
         run: echo "DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
     
       - name: Fetch GitHub Models
-        uses: datajourneyhq/list-github-models@v1.0.0
+        uses: datajourneyhq/list-github-models@RELEASE
         with:
           artifact-name: 'models-${{ env.DATE }}'

--- a/.github/workflows/sync-release-tag.yml
+++ b/.github/workflows/sync-release-tag.yml
@@ -1,0 +1,43 @@
+name: Sync RELEASE Tag
+
+on:
+  push:
+    tags:
+      - 'v*'  # Triggers on version tags like v1.0.0, v1.1.0, etc.
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  sync-release-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history and tags
+
+      - name: Get latest version tag
+        id: latest-tag
+        run: |
+          # Get the latest version tag (sorted by version)
+          LATEST_TAG=$(git tag -l "v*" | sort -V | tail -n1)
+          echo "Latest tag: $LATEST_TAG"
+          echo "tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+
+      - name: Update RELEASE tag
+        run: |
+          # Delete existing RELEASE tag if it exists
+          git tag -d RELEASE 2>/dev/null || true
+          git push origin :refs/tags/RELEASE 2>/dev/null || true
+          
+          # Create new RELEASE tag pointing to latest version
+          git tag RELEASE ${{ steps.latest-tag.outputs.tag }}
+          git push origin RELEASE
+
+      - name: Verify RELEASE tag
+        run: |
+          echo "RELEASE tag now points to: $(git rev-parse RELEASE)"
+          echo "Latest version tag points to: $(git rev-parse ${{ steps.latest-tag.outputs.tag }})"

--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ One fine day, without warning, a few of our trusted models vanished from the lis
 ### Basic Usage
 
 ```yaml
-# vx.y.z = latest version tag
-# example v1.0.0
 name: Track GitHub Models
 on:
   schedule:
@@ -37,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: datajourneyhq/list-github-models@vx.y.z
+      - uses: datajourneyhq/list-github-models@RELEASE
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -45,9 +43,7 @@ jobs:
 ### Advanced Usage
 
 ```yaml
-# vx.y.z = latest version tag
-# example v1.0.0
-- uses: datajourneyhq/list-github-models@vx.y.z
+- uses: datajourneyhq/list-github-models@RELEASE
   with:
     github-token: ${{ secrets.GITHUB_TOKEN }}
     artifact-name: 'my-custom-models-catalog'
@@ -94,8 +90,6 @@ Human-readable markdown report with model listings:
 ## Example Workflow
 
 ```yaml
-# vx.y.z = latest version tag
-# example v1.0.0
 name: Daily GitHub Models Tracking
 
 on:
@@ -117,7 +111,7 @@ jobs:
       run: echo "DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
     - name: Fetch GitHub Models
-      uses: datajourneyhq/list-github-models@vx.y.z
+      uses: datajourneyhq/list-github-models@RELEASE
       with:
         artifact-name: 'models-${{ env.DATE }}'
 ```


### PR DESCRIPTION
This pull request updates documentation and workflows to standardize the use of the `RELEASE` tag for the `datajourneyhq/list-github-models` GitHub Action, and introduces automation to keep the `RELEASE` tag in sync with the latest versioned release. This ensures users always reference the most current stable version by using `@RELEASE`.

**Workflow automation:**

* Added a new workflow `.github/workflows/sync-release-tag.yml` that automatically updates the `RELEASE` tag to point to the latest version tag whenever a new version tag is pushed or a release is published. This helps keep the `RELEASE` tag always aligned with the most recent release.

**Documentation and workflow usage updates:**

* Updated all usage examples in `README.md` to reference `datajourneyhq/list-github-models@RELEASE` instead of a specific version tag, simplifying instructions and encouraging use of the rolling release tag. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L28-L29) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L40-R46) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L97-L98) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L120-R114)
* Modified the workflow `.github/workflows/list-Github-models.yml` to use the `RELEASE` tag for the `list-github-models` action, ensuring the workflow always uses the latest stable release.This pull request updates the version references for the `datajourneyhq/list-github-models` GitHub Action from specific version tags to the `RELEASE` tag, both in the workflow configuration and throughout the documentation. This ensures that users and workflows always use the latest released version of the Action, simplifying maintenance and reducing confusion about which version to use.

**Workflow configuration updates:**

* Updated the `list-Github-models.yml` workflow to use `datajourneyhq/list-github-models@RELEASE` instead of `@v1.0.0` when fetching GitHub models.

**Documentation updates:**

* Replaced all example usages of `datajourneyhq/list-github-models@vx.y.z` or `@v1.0.0` in `README.md` with `@RELEASE` to reflect the new recommended usage. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L28-L29) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L40-R46) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L97-L98) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L120-R114)
* Removed explanatory comments about version tags in the example YAML snippets in `README.md` for clarity and consistency. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L28-L29) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L40-R46) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L97-L98)